### PR TITLE
fix clipboard history crash

### DIFF
--- a/src/clipboard/item.rs
+++ b/src/clipboard/item.rs
@@ -43,11 +43,7 @@ impl ClipboardItem {
         match &self.content {
             ClipboardContent::Text(text) => {
                 let first_line = text.lines().next().unwrap_or("");
-                if first_line.len() > MAX_LENGTH {
-                    format!("{}...", &first_line[..MAX_LENGTH])
-                } else {
-                    first_line.to_string()
-                }
+                truncate_preview_line(first_line, MAX_LENGTH)
             }
             ClipboardContent::Image { .. } => "[Image]".to_string(),
             ClipboardContent::FilePaths(paths) => {
@@ -63,11 +59,7 @@ impl ClipboardItem {
             }
             ClipboardContent::RichText { plain, .. } => {
                 let first_line = plain.lines().next().unwrap_or("");
-                if first_line.len() > MAX_LENGTH {
-                    format!("{}...", &first_line[..MAX_LENGTH])
-                } else {
-                    first_line.to_string()
-                }
+                truncate_preview_line(first_line, MAX_LENGTH)
             }
         }
     }
@@ -110,5 +102,16 @@ impl ClipboardItem {
             );
         }
         false
+    }
+}
+
+/// Truncate wihtout splitting emojis
+fn truncate_preview_line(line: &str, max: usize) -> String {
+    let truncated: String = line.chars().take(max).collect();
+
+    if truncated.len() < line.len() {
+        format!("{}...", truncated)
+    } else {
+        truncated
     }
 }


### PR DESCRIPTION
The small preview cut right trough emojis if the emoji was perfectly placed causing a panic.

The text I had the issue with: 
```
zlaunch on  main [!] is 📦 v0.4.0 via 🦀 v1.92.0-nightly
```

When you have this in your history and try to open the clipboard the daemon crashes. This pr fixes that.


this was the crash:
```bash
thread 'main' (344750) panicked at src/clipboard/item.rs:47:49:
byte index 30 is not a char boundary; it is inside '📦' (bytes 27..31) of `zlaunch on  main [!] is 📦 v0.4.0 via 🦀 v1.92.0-nightly`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```