### PR TITLE
Configurable icon border radius

### DIFF
--- a/assets/themes/ayu-dark.toml
+++ b/assets/themes/ayu-dark.toml
@@ -24,6 +24,7 @@ item_content_height = 34.0
 
 # Icons
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#0d1016"  # Selection bg
 icon_placeholder_color = "#4d5566"       # Comment
 

--- a/assets/themes/catppuccin-latte.toml
+++ b/assets/themes/catppuccin-latte.toml
@@ -24,6 +24,7 @@ item_content_height = 34.0
 
 # Icons
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#e6e9ef"  # Surface0
 icon_placeholder_color = "#9ca0b0"       # Overlay0
 

--- a/assets/themes/catppuccin-mocha.toml
+++ b/assets/themes/catppuccin-mocha.toml
@@ -24,6 +24,7 @@ item_content_height = 34.0
 
 # Icons
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#313244"  # Surface0
 icon_placeholder_color = "#6c7086"       # Overlay0
 

--- a/assets/themes/dracula.toml
+++ b/assets/themes/dracula.toml
@@ -24,6 +24,7 @@ item_content_height = 38.0
 
 # Icons - larger
 icon_size = 28.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#44475a"
 icon_placeholder_color = "#6272a4"
 

--- a/assets/themes/everforest.toml
+++ b/assets/themes/everforest.toml
@@ -24,6 +24,7 @@ item_content_height = 38.0
 
 # Icons
 icon_size = 28.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#323d43"
 icon_placeholder_color = "#859289"
 

--- a/assets/themes/gruvbox-dark.toml
+++ b/assets/themes/gruvbox-dark.toml
@@ -24,6 +24,7 @@ item_content_height = 34.0
 
 # Icons
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#3c3836"  # bg1
 icon_placeholder_color = "#928374"       # gray
 

--- a/assets/themes/kanagawa.toml
+++ b/assets/themes/kanagawa.toml
@@ -24,6 +24,7 @@ item_content_height = 35.0
 
 # Icons - moderate size
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#16161d"
 icon_placeholder_color = "#727169"
 

--- a/assets/themes/material.toml
+++ b/assets/themes/material.toml
@@ -24,6 +24,7 @@ item_content_height = 42.0
 
 # Icons - material size
 icon_size = 30.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#2e3c43"
 icon_placeholder_color = "#546e7a"
 

--- a/assets/themes/monokai.toml
+++ b/assets/themes/monokai.toml
@@ -24,6 +24,7 @@ item_content_height = 36.0
 
 # Icons
 icon_size = 26.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#3e3d32"
 icon_placeholder_color = "#75715e"
 

--- a/assets/themes/nord.toml
+++ b/assets/themes/nord.toml
@@ -24,6 +24,7 @@ item_content_height = 34.0
 
 # Icons
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#3b4252"  # Polar Night 1
 icon_placeholder_color = "#4c566a"       # Polar Night 3
 

--- a/assets/themes/one-dark.toml
+++ b/assets/themes/one-dark.toml
@@ -24,6 +24,7 @@ item_content_height = 40.0
 
 # Icons - extra large
 icon_size = 32.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#21252b"
 icon_placeholder_color = "#5c6370"
 

--- a/assets/themes/rose-pine.toml
+++ b/assets/themes/rose-pine.toml
@@ -24,6 +24,7 @@ item_content_height = 37.0
 
 # Icons
 icon_size = 27.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#1f1d2e"
 icon_placeholder_color = "#6e6a86"
 

--- a/assets/themes/solarized-dark.toml
+++ b/assets/themes/solarized-dark.toml
@@ -24,6 +24,7 @@ item_content_height = 32.0
 
 # Icons - standard size
 icon_size = 22.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#073642"
 icon_placeholder_color = "#586e75"
 

--- a/assets/themes/synthwave.toml
+++ b/assets/themes/synthwave.toml
@@ -24,6 +24,7 @@ item_content_height = 40.0
 
 # Icons - glowing
 icon_size = 32.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#34294f"
 icon_placeholder_color = "#ff7edb"   # Neon pink
 

--- a/assets/themes/tokyo-night.toml
+++ b/assets/themes/tokyo-night.toml
@@ -24,6 +24,7 @@ item_content_height = 34.0
 
 # Icons
 icon_size = 24.0
+icon_border_radius = 4.0
 icon_placeholder_background = "#24283b"  # Terminal black
 icon_placeholder_color = "#565f89"       # Comment
 

--- a/src/ui/components/list_item.rs
+++ b/src/ui/components/list_item.rs
@@ -160,12 +160,12 @@ fn render_icon_element(icon: Icon) -> Div {
         Icon::Path(path) => {
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             if matches!(ext, "png" | "jpg" | "jpeg" | "svg") {
-                icon_container.child(img(path).w(size).h(size).rounded_sm())
+                icon_container.child(img(path).w(size).h(size).rounded(theme.icon_border_radius))
             } else {
                 render_placeholder_icon(icon_container, "?")
             }
         }
-        Icon::Data(image) => icon_container.child(img(image).w(size).h(size).rounded_sm()),
+        Icon::Data(image) => icon_container.child(img(image).w(size).h(size).rounded(theme.icon_border_radius)),
         Icon::Named(_name) => {
             // For named icons, we'd typically use an icon library
             // For now, use placeholder
@@ -180,7 +180,7 @@ fn render_placeholder_icon(container: Div, text: &str) -> Div {
     let theme = theme();
     container
         .bg(theme.icon_placeholder_background)
-        .rounded_sm()
+        .rounded(theme.icon_border_radius)
         .child(
             div()
                 .text_sm()

--- a/src/ui/components/list_item.rs
+++ b/src/ui/components/list_item.rs
@@ -165,7 +165,9 @@ fn render_icon_element(icon: Icon) -> Div {
                 render_placeholder_icon(icon_container, "?")
             }
         }
-        Icon::Data(image) => icon_container.child(img(image).w(size).h(size).rounded(theme.icon_border_radius)),
+        Icon::Data(image) => {
+            icon_container.child(img(image).w(size).h(size).rounded(theme.icon_border_radius))
+        }
         Icon::Named(_name) => {
             // For named icons, we'd typically use an icon library
             // For now, use placeholder

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -425,6 +425,8 @@ pub struct LauncherTheme {
     // Icons
     #[serde(with = "pixels_serde")]
     pub icon_size: Pixels,
+    #[serde(with = "pixels_serde")]
+    pub icon_border_radius: Pixels,
     #[serde(with = "hsla_serde")]
     pub icon_placeholder_background: Hsla,
     #[serde(with = "hsla_serde")]
@@ -579,6 +581,7 @@ impl Default for LauncherTheme {
 
             // Icons
             icon_size: px(24.0),
+            icon_border_radius: px(4.0),
             icon_placeholder_background: hsla(0.0, 0.0, 1.0, 0.04), // ~4% white
             icon_placeholder_color: hsla(0.0, 0.0, 1.0, 0.25),      // 25% white
 

--- a/src/ui/views/clipboard_rendering.rs
+++ b/src/ui/views/clipboard_rendering.rs
@@ -97,7 +97,7 @@ fn render_item_icon(item: &ClipboardItem) -> Div {
                 .items_center()
                 .justify_center()
                 .bg(t.icon_placeholder_background)
-                .rounded_sm()
+                .rounded(t.icon_border_radius)
                 .child(
                     div()
                         .w(t.clipboard.color_icon_size)
@@ -209,7 +209,7 @@ fn render_icon_container(icon: PhosphorIcon) -> Div {
         .items_center()
         .justify_center()
         .bg(t.icon_placeholder_background)
-        .rounded_sm()
+        .rounded(t.icon_border_radius)
         .child(
             svg()
                 .path(icon.path())

--- a/src/ui/views/item_rendering.rs
+++ b/src/ui/views/item_rendering.rs
@@ -172,7 +172,7 @@ fn render_calculator_icon() -> Div {
         .items_center()
         .justify_center()
         .bg(icon_bg)
-        .rounded_sm()
+        .rounded(theme.icon_border_radius)
         .child(
             div()
                 .text_sm()
@@ -280,7 +280,7 @@ fn render_icon_from_data(data: &[u8]) -> Div {
         .justify_center();
 
     let image = Arc::new(gpui::Image::from_bytes(ImageFormat::Png, data.to_vec()));
-    icon_container.child(img(image).w(size).h(size).rounded_sm())
+    icon_container.child(img(image).w(size).h(size).rounded(theme.icon_border_radius))
 }
 
 /// Render an icon from a file path, with fallback placeholder.
@@ -299,14 +299,14 @@ pub fn render_icon(icon_path: Option<&PathBuf>) -> Div {
     if let Some(path) = icon_path {
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
         if matches!(ext, "png" | "jpg" | "jpeg" | "svg") {
-            return icon_container.child(img(path.clone()).w(size).h(size).rounded_sm());
+            return icon_container.child(img(path.clone()).w(size).h(size).rounded(theme.icon_border_radius));
         }
     }
 
     // Fallback: show a subtle placeholder
     icon_container
         .bg(theme.icon_placeholder_background)
-        .rounded_sm()
+        .rounded(theme.icon_border_radius)
         .child(
             div()
                 .text_sm()
@@ -328,7 +328,7 @@ pub fn render_phosphor_icon(icon: Option<PhosphorIcon>) -> Div {
         .items_center()
         .justify_center()
         .bg(theme.icon_placeholder_background)
-        .rounded_sm();
+        .rounded(theme.icon_border_radius);
 
     if let Some(icon) = icon {
         icon_container.child(

--- a/src/ui/views/item_rendering.rs
+++ b/src/ui/views/item_rendering.rs
@@ -299,7 +299,12 @@ pub fn render_icon(icon_path: Option<&PathBuf>) -> Div {
     if let Some(path) = icon_path {
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
         if matches!(ext, "png" | "jpg" | "jpeg" | "svg") {
-            return icon_container.child(img(path.clone()).w(size).h(size).rounded(theme.icon_border_radius));
+            return icon_container.child(
+                img(path.clone())
+                    .w(size)
+                    .h(size)
+                    .rounded(theme.icon_border_radius),
+            );
         }
     }
 


### PR DESCRIPTION
This pr allows the user to set icon_border_radius in their theme to configure the border radius of the square behind the icons.

<img width="179" height="45" alt="image" src="https://github.com/user-attachments/assets/7729e3f3-71cb-4cac-8309-e3cbd57310ed" />
<img width="185" height="48" alt="image" src="https://github.com/user-attachments/assets/482577ea-c00f-4dca-b274-6f6442699b94" />
<img width="171" height="48" alt="image" src="https://github.com/user-attachments/assets/f1d50e7d-bb37-4077-ae38-ec56653b7f5a" />
