### PR TITLE
Customizable font

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,8 @@ pub mod validation;
 
 // Re-export types
 pub use types::{
-    AppConfig, ConfigModule, ConfigSearchProvider, FuzzyMatchConfig, LauncherMode, LayerShellLayer,
+    AppConfig, ConfigModule, ConfigSearchProvider, FontConfig, FuzzyMatchConfig, LauncherMode,
+    LayerShellLayer,
 };
 
 // Re-export service functions

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -94,6 +94,8 @@ impl Default for FuzzyMatchConfig {
 pub struct FontConfig {
     /// Font family name, for example "CaskaydiaCove Nerd Font Mono".
     pub font_family: Option<String>,
+    /// Font family name, for example "Mononoki Nerd Font Mono"
+    pub mono_font_family: Option<String>,
     /// Font size in pixels.
     pub font_size: Option<f32>,
 }
@@ -102,6 +104,7 @@ impl Default for FontConfig {
     fn default() -> Self {
         Self {
             font_family: None,
+            mono_font_family: None,
             font_size: None,
         }
     }
@@ -166,6 +169,7 @@ impl AppConfig {
             layer_shell_layer: LayerShellLayer::Overlay,
             font: FontConfig {
                 font_family: None,
+                mono_font_family: None,
                 font_size: None,
             },
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -88,6 +88,25 @@ impl Default for FuzzyMatchConfig {
     }
 }
 
+/// Font configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FontConfig {
+    /// Font family name, for example "CaskaydiaCove Nerd Font Mono".
+    pub font_family: Option<String>,
+    /// Font size in pixels.
+    pub font_size: Option<f32>,
+}
+
+impl Default for FontConfig {
+    fn default() -> Self {
+        Self {
+            font_family: None,
+            font_size: None,
+        }
+    }
+}
+
 /// Application configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -124,6 +143,9 @@ pub struct AppConfig {
     /// Default: `Overlay`. Use `Top` if another surface (e.g. an input-method
     /// popup) needs to render above the launcher.
     pub layer_shell_layer: LayerShellLayer,
+    /// Font configuration for the launcher UI.
+    /// Can be overridden by the active theme's `[font]` section.
+    pub font: FontConfig,
 }
 
 impl AppConfig {
@@ -142,6 +164,10 @@ impl AppConfig {
             combined_modules: None,
             fuzzy_match: FuzzyMatchConfig::default_const(),
             layer_shell_layer: LayerShellLayer::Overlay,
+            font: FontConfig {
+                font_family: None,
+                font_size: None,
+            },
         }
     }
 
@@ -191,6 +217,7 @@ impl Default for AppConfig {
             combined_modules: None,
             fuzzy_match: FuzzyMatchConfig::default(),
             layer_shell_layer: LayerShellLayer::default(),
+            font: FontConfig::default(),
         }
     }
 }

--- a/src/daemon/theme.rs
+++ b/src/daemon/theme.rs
@@ -1,7 +1,7 @@
 //! Theme configuration and handling for the daemon.
 
 use crate::error::IpcError;
-use gpui::hsla;
+use gpui::{hsla, px};
 use gpui_component::theme::Theme;
 
 /// Handle the SetTheme IPC command.
@@ -27,11 +27,30 @@ pub fn handle_set_theme(name: &str) -> Result<(), IpcError> {
 /// Sets up transparent backgrounds and minimal borders for the overlay look.
 pub fn configure_theme(cx: &mut gpui::App) {
     let theme = Theme::global_mut(cx);
+    let config = crate::config::config();
+    let theme_config = crate::ui::theme::theme();
+
+    // Get font family and size from config
+    let font_family = theme_config
+        .font
+        .font_family
+        .clone()
+        .or(config.font.font_family.clone()); // Fallback to config font if theme has no font set
+    let font_size = theme_config.font.font_size.or(config.font.font_size);
+
+    // Apply font family and size
+    if let Some(family) = font_family {
+        theme.font_family = family.into();
+    }
+    if let Some(size) = font_size {
+        theme.font_size = px(size);
+    }
+
+    // Set the background overlay thing
     theme.background = hsla(0.0, 0.0, 0.0, 0.0); // Fully transparent
     theme.window_border = hsla(0.0, 0.0, 0.0, 0.0); // No window border
     theme.border = hsla(0.0, 0.0, 1.0, 0.1); // Subtle separator between search and list
     theme.list_active_border = hsla(0.0, 0.0, 0.0, 0.0); // No selection border
     theme.list_active = hsla(0.0, 0.0, 0.0, 0.0); // Fully transparent - we handle selection ourselves
     theme.list_hover = hsla(0.0, 0.0, 0.0, 0.0); // Fully transparent - we handle hover ourselves
-    theme.mono_font_family = "Mononoki Nerd Font Mono".into(); // Monospace font for code blocks
 }

--- a/src/daemon/theme.rs
+++ b/src/daemon/theme.rs
@@ -36,12 +36,24 @@ pub fn configure_theme(cx: &mut gpui::App) {
         .font_family
         .clone()
         .or(config.font.font_family.clone()); // Fallback to config font if theme has no font set
+
+    let mono_font_family = theme_config
+        .font
+        .mono_font_family
+        .clone()
+        .or(config.font.mono_font_family.clone()); // Fallback to config font if theme has no font set
+
     let font_size = theme_config.font.font_size.or(config.font.font_size);
 
     // Apply font family and size
     if let Some(family) = font_family {
         theme.font_family = family.into();
     }
+
+    if let Some(family) = mono_font_family {
+        theme.mono_font_family = family.into();
+    }
+
     if let Some(size) = font_size {
         theme.font_size = px(size);
     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -319,9 +319,6 @@ pub struct MarkdownTheme {
     /// Border radius for code blocks
     #[serde(with = "pixels_serde")]
     pub code_block_radius: Pixels,
-    /// Font family for code blocks
-    #[serde(skip)]
-    pub code_font_family: &'static str,
     /// Line height for code text
     #[serde(with = "pixels_serde")]
     pub code_line_height: Pixels,
@@ -520,7 +517,6 @@ impl Default for MarkdownTheme {
             paragraph_line_height: px(20.0),
             heading_line_height: px(22.0),
             code_block_radius: px(6.0),
-            code_font_family: "Hack Nerd Font Mono",
             code_line_height: px(18.0),
         }
     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,3 +1,4 @@
+use crate::config::FontConfig;
 use gpui::{Hsla, Pixels, hsla, px};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -438,6 +439,10 @@ pub struct LauncherTheme {
     #[serde(with = "hsla_serde")]
     pub empty_state_color: Hsla,
 
+    // Font
+    #[serde(default)]
+    pub font: FontConfig,
+
     // Sub-themes for specific components
     pub calculator: CalculatorTheme,
     pub action_indicator: ActionIndicatorTheme,
@@ -588,6 +593,9 @@ impl Default for LauncherTheme {
             // Empty state
             empty_state_height: px(200.0),
             empty_state_color: hsla(0.0, 0.0, 1.0, 0.25), // 25% white
+
+            // Use font Default implementation
+            font: FontConfig::default(),
 
             // Sub-themes use their Default implementations
             calculator: CalculatorTheme::default(),


### PR DESCRIPTION
Allows customizing the font family and font size in both the theme toml and config.toml
```toml
[font]
font_family = "CaskaydiaCove Nerd Font Mono"
mono_font_family = "CaskaydiaCove Nerd Font Mono"
font_size = 20
```

If it's set in both the theme toml and config.toml then the theme will win.

Closes #42